### PR TITLE
fix: Don't highlight keywords if there's no preceding whitespace

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -425,7 +425,7 @@ impl Row {
     ) -> bool {
         if *index > 0 {
             let prev_char = chars[*index - 1];
-            if !is_separator(prev_char) {
+            if !prev_char.is_ascii_whitespace() {
                 return false;
             }
         }


### PR DESCRIPTION
# Summary

This PR fixes an issue where keywords would be highlighted if, say, an underscore was preceding it. The fix is to check for preceding whitespace, rather than a separator.

#### Attached issue

Closes #27 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes and have added any tests as needed.
- [x] I have added comments in hard-to-understand areas.
- [x] I have made any necessary changes to documentation.
