### PR TITLE
feat: Add built-in calculator for math expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ name = "ferro"
 version = "0.4.0"
 dependencies = [
  "lazy_static",
+ "shunting",
  "termbg",
  "termion",
  "unicode-segmentation",
@@ -272,6 +273,17 @@ dependencies = [
  "parking",
  "pin-project-lite",
  "waker-fn",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -329,10 +341,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexers"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82de9bb5d9e8ff5e13532a45583ea972e220b8a6efef755daad1f285333a8afa"
+
+[[package]]
 name = "libc"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "lock_api"
@@ -389,6 +413,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -470,6 +504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +525,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -510,6 +590,18 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "shunting"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6bc210d95d59fbf54a2849a956866f9ec11f8e2ca3595a6d3f94e8d5b4cd74f"
+dependencies = [
+ "lexers",
+ "libm",
+ "rand",
+ "rand_distr",
+]
 
 [[package]]
 name = "signal-hook"
@@ -641,6 +733,12 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 lazy_static = "1.4.0"
+shunting = "0.1.2"
 termbg = "0.4.1"
 termion = "1.5.6"
 unicode-segmentation = "1.9.0"

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Based on [Philipp Flenker's](https://www.philippflenker.com/hecto/) Rust text ed
 * Incremental forward and backward search
 * Search-and-delete / search-and-replace
 * Auto-indentation
-* UTF-8 support (mostly)
+* Built-in calculator

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -2,6 +2,7 @@ use crate::Document;
 use crate::Row;
 use crate::Terminal;
 
+use shunting::{MathContext, ShuntingParser};
 use std::env;
 use std::time::Duration;
 use std::time::Instant;
@@ -338,6 +339,23 @@ impl Editor {
         self.document.refresh_highlighting();
     }
 
+    /// Prompts the user for a mathematical expression and displays its evaluated result.
+    fn evaluate_expression(&mut self) {
+        let query = self
+            .prompt("Enter your expression: ", |_, _, _| {})
+            .unwrap_or(None)
+            .unwrap_or(String::new());
+
+        if let Ok(expr) = ShuntingParser::parse_str(&query) {
+            if let Ok(result) = MathContext::new().eval(&expr) {
+                self.status_message = StatusMessage::from(format!("Result = {}", result));
+                return;
+            }
+        }
+
+        self.status_message = StatusMessage::from("Invalid expression.".into());
+    }
+
     /// Processes an event (i.e. a keypress or a mousepress).
     ///
     /// # Errors
@@ -377,6 +395,7 @@ impl Editor {
             }
             Key::Ctrl('s') => self.save(),
             Key::Ctrl('l') => self.search(),
+            Key::Alt('c') => self.evaluate_expression(),
             Key::Char(c) => {
                 let indent = self.document.insert(&mut self.cursor_position, c);
                 (0..indent + 1).for_each(|_| self.move_cursor(Key::Right));


### PR DESCRIPTION
# Summary

This PR adds a simple calculator to the text editor using the `Alt + C` keybinding. The text editor prompts the user for a mathematical expression and displays its result.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes and have added any tests as needed.
- [x] I have added comments in hard-to-understand areas.
- [x] I have made any necessary changes to documentation.
